### PR TITLE
[FEAT] Função para configuração rápida de teste-de-teste

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ __pycache__/
 /doc/linkcheck/
 /pytest_dependency.egg-info/
 /python2_6.patch
-.venv

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 /doc/linkcheck/
 /pytest_dependency.egg-info/
 /python2_6.patch
+.venv

--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -4,9 +4,11 @@ __version__ = "$VERSION"
 
 import logging
 import pytest
+from _pytest.mark.structures import ParameterSet
+
 import inspect
 from types import ModuleType
-from typing import Callable, List, Type, Union
+from typing import Callable, List, Type
 
 logger = logging.getLogger(__name__)
 

--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -255,6 +255,11 @@ def build_mocked_assets(
     of `asset_to_mock` configured as XFAIL dependencies when running
     `test_function`.
 
+    The lookup for mocking implementations in `mocks_module` checks if:
+    - the asset is a function or class
+    - the asset's name starts with '_test' (case insensitive)
+    - the asset's module is `mocks_module` (avoids unwanted importings)
+
     Parameters
     ----------
     `mocks_module` : ModuleType

--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -1,11 +1,6 @@
-"""pytest-dependency - Manage dependencies of tests
+"""$DOC"""
 
-This pytest plugin manages dependencies of tests.  It allows to mark
-some tests as dependent from other tests.  These tests will then be
-skipped if any of the dependencies did fail or has been skipped.
-"""
-
-__version__ = "UNKNOWN"
+__version__ = "$VERSION"
 
 import logging
 import pytest

--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -4,9 +4,11 @@ __version__ = "$VERSION"
 
 import logging
 import pytest
+from _pytest.mark.structures import ParameterSet
+
 import inspect
 from types import ModuleType
-from typing import Callable, List, Type, Union
+from typing import Callable, List, Type
 
 logger = logging.getLogger(__name__)
 
@@ -242,59 +244,72 @@ def mark_xfail(mocked, expected: Type[BaseException] = AssertionError):
 
 def build_mocked_assets(
     mocks_module: ModuleType,
-    asset_to_mock: Union[Callable, Type],
+    asset_to_mock: Callable,
     test_function: Callable,
-    **expected_raise: Type[BaseException],
-) -> List:
+    custom_exceptions: dict[Callable, Type[BaseException]] = {},
+) -> List[ParameterSet]:
     """
-    Sets up parameters with mocked implementations expected to fail.
+    Builds the parameters for a test-testing fixture.
+
+    Returns a list of the mocking implementations (present in `mocks_module`)
+    of `asset_to_mock` configured as XFAIL dependencies when running
+    `test_function`.
 
     Parameters
     ----------
-    `mocks_module` : module
-        the module that contains the mocking assets (paremeters)
+    `mocks_module` : ModuleType
+        the module that contains the mocking assets (parameters)
     `asset_to_mock` : function or class
         the asset (function or class) intended to be mocked
     `test_function` : function
         the test function which will be parametrized
-    keyword arguments:
-        replace default xfail exception for a given mocking asset
-        Example: `build_mocked_assets(..., _TestSomeClass=TypeError)`
+    `custom_exceptions` : dict
+        Dictionary of [mocking asset -> expected exception] to replace the
+        default XFAIL exceptions (`AssertionError`).
+        Example:
+        `build_mocked_assets(..., custom_exceptions={_TestThisFunc:TypeError})`
 
     Returns
     -------
-    `list`
-        Configured mocked params for pytest fixture parametrization.
+    `list[ParameterSet]`
+        Configured mocking params for the pytest parametrization.
     """
     asset_map = _build_asset_map(mocks_module)
-    mocked_tests = [
-        f"{test_function.__name__}[{asset_name}]" for asset_name in asset_map
+
+    if any(asset not in asset_map for asset in custom_exceptions):
+        raise ValueError(
+            "All keys for 'custom_exceptions' dict must be an asset of "
+            f"module {mocks_module}."
+        )
+
+    mocked_test_names = [
+        f"{test_function.__name__}[{asset_name}]"
+        for asset_name in asset_map.values()
     ]
 
-    mocking_config = _build_mocking_config(
-        asset_to_mock, expected_raise, asset_map, mocked_tests
+    return _build_mocking_config(
+        asset_to_mock, custom_exceptions, asset_map, mocked_test_names
     )
-    return mocking_config
 
 
 def _build_mocking_config(
-    asset_to_mock, expected_raise, asset_map, _mocked_tests
-):
-    _mocking_config = [
+    asset_to_mock, custom_exceptions, asset_map, mocked_test_names
+) -> List[ParameterSet]:
+    mocking_config = [
         mark_xfail(asset)
-        for asset_name, asset in asset_map.items()
-        if asset_name not in expected_raise
+        for asset in asset_map
+        if asset not in custom_exceptions
     ]
-    for asset_name, expected in expected_raise.items():
-        _mocking_config.append(mark_xfail(asset_map[asset_name], expected))
+    for asset, expected in custom_exceptions.items():
+        mocking_config.append(mark_xfail(asset, expected))
 
-    _mocking_config.append(mark_dependency(asset_to_mock, _mocked_tests))
-    return _mocking_config
+    mocking_config.append(mark_dependency(asset_to_mock, mocked_test_names))
+    return mocking_config
 
 
 def _build_asset_map(mocks_module):
     return {
-        asset_name: asset
+        asset: asset_name
         for asset_name, asset in inspect.getmembers(mocks_module)
         if (
             (inspect.isclass(asset) or inspect.isfunction(asset))

--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -267,14 +267,14 @@ def build_mocked_assets(
         Configured mocked params for pytest fixture parametrization.
     """
     asset_map = _build_asset_map(mocks_module)
-    _mocked_tests = [
+    mocked_tests = [
         f"{test_function.__name__}[{asset_name}]" for asset_name in asset_map
     ]
 
-    _mocking_config = _build_mocking_config(
-        asset_to_mock, expected_raise, asset_map, _mocked_tests
+    mocking_config = _build_mocking_config(
+        asset_to_mock, expected_raise, asset_map, mocked_tests
     )
-    return _mocking_config
+    return mocking_config
 
 
 def _build_mocking_config(

--- a/src/pytest_dependency.py
+++ b/src/pytest_dependency.py
@@ -2,13 +2,13 @@
 
 __version__ = "$VERSION"
 
-import logging
-import pytest
-from _pytest.mark.structures import ParameterSet
-
 import inspect
+import logging
 from types import ModuleType
 from typing import Callable, List, Type
+
+import pytest
+from _pytest.mark.structures import ParameterSet
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
A nova função `build_mocked_assets` elimine duplicação de código e re-trabalho quando queremos criar ou alterar um requisito de teste dos projetos da Trybe.

Atualmente há a necessidade de listar cada classe/função "fake" duas vezes dentro do arquivo `conftest.py`. Com essa nova configuração, só é necessário sinalizar a fonte das classes/funções "fake" e quais são os casos diferentes do XFAIL default. Exemplo: https://github.com/betrybe/sd-0x-tech-news/tree/fast-test-example/tests/reading_plan 

Além disso, o arquivo `marker.py` não é necessário.

# Antes
```python
from unittest.mock import patch
import pytest

from _pytest.outcomes import Failed
from tests.reading_plan import mocks
from tech_news.analyzer.reading_plan import ReadingPlanService
from tests.marker import (
    mark_dependency,
    mark_xfail,
)

mocked_tests = [
    "test_reading_plan_group_news[_TestAllowInvalidValue]",
    "test_reading_plan_group_news[_TestEmptyUnreadableNews]",
    "test_reading_plan_group_news[_TestDuplicateUnreadableNews]",
    "test_reading_plan_group_news[_TestWrongUnfilledTime]",
]

mocking = [
    mark_xfail(mocks._TestWrongUnfilledTime),
    mark_xfail(mocks._TestEmptyUnreadableNews),
    mark_xfail(mocks._TestDuplicateUnreadableNews),
    mark_xfail(mocks._TestAllowInvalidValue, expected=Failed),
    mark_dependency(ReadingPlanService, mocked_tests),
]


@pytest.fixture(params=mocking, autouse=True)
def mock_it(request):
    with patch(
        "tests.reading_plan.test_reading_plan.ReadingPlanService",
        request.param,
    ):
        yield
```
# Depois
```python
from unittest.mock import patch

import pytest
from _pytest.outcomes import Failed
from pytest_dependency import build_mocked_assets

from tech_news.analyzer.reading_plan import ReadingPlanService
from tests.reading_plan import mocks
from tests.reading_plan.test_reading_plan import test_reading_plan_group_news


mocked_assets = build_mocked_assets(
    mocks_module=mocks,
    asset_to_mock=ReadingPlanService,
    test_function=test_reading_plan_group_news,
    custom_exceptions={mocks._TestAllowInvalidValue: Failed},
)


@pytest.fixture(params=mocked_assets, autouse=True)
def mock_it(request):
    with patch(
        "tests.reading_plan.test_reading_plan.ReadingPlanService",
        request.param,
    ):
        yield
```